### PR TITLE
docs: add specification for SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,164 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+*reports/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# Local VSCode
+.vscode/

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,5 +1,25 @@
 # OSCAL Compass SDK Specification
 
+<details>
+<summary>Table of Contents</summary>
+
+<!-- toc -->
+- [OSCAL Compass SDK Specification](#oscal-compass-sdk-specification)
+  - [Scope](#scope)
+  - [Goals](#goals)
+    - [Multi-Language Support](#multi-language-support)
+    - [Usabilty](#usabilty)
+  - [Core Functionality](#core-functionality)
+    - [1. OSCAL Support](#1-oscal-support)
+    - [2. OSCAL Extensions Support](#2-oscal-extensions-support)
+    - [3. OSCAL Validation](#3-oscal-validation)
+    - [4. OSCAL Transformation](#4-oscal-transformation)
+    - [5. OSCAL Profile Resolution](#5-oscal-profile-resolution)
+  - [Future Consideration](#future-consideration)
+<!-- tocstop -->
+
+</details>
+
 ## Scope
 
 This document specifies the functional requirements for OSCAL Compass SDK developed to work with OSCAL documents.
@@ -8,27 +28,64 @@ The keywords "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD,"
 "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
-## Non-Goals
-
 ## Goals
+
+### Multi-Language Support
+
+* **Functionality Consistency:** Offer a functionally consistent developer experience across all supported languages.
+* **Language-Specific Idioms:**  Each SDK should adhere to the conventions and best practices of its target language.
+
+### Usabilty
+
+* **Ease of Use:**  Provide an intuitive API for developers to interact with OSCAL data.
+* **Versioning:** Each SDK **MUST** follow semantic versioning to clearly communicate changes and ensure compatibility.
+* **Extensibility**: Offer mechanisms for developers to customize with alternate implementations, while providing sensible defaults.
+
+Each SDK **SHOULD** have comprehensive documentation, including:
+
+* **API Reference:**  Detailed documentation of all classes, methods, and functions. This could be generated from code comments.
+* **User Guide:**  Tutorials and examples to help developers get started with the SDK.
+* **Code Samples:**  Provide boilerplate code examples demonstrating common use cases.
 
 ## Core Functionality
 
-### 1. Common OSCAL Extensions
+### 1. OSCAL Support
 
-*  **Rule Extension**: The SDK **MUST** define and support workflow around the OSCAL Compass RuleSet OSCAL extension.
+* **OSCAL Schema:** Support the official [OSCAL](https://pages.nist.gov/OSCAL/) schema definitions.
+* **OSCAL Data Formats**
+  * SDKs **MUST** support the JSON format
+  * SDKs **MAY**  support XML and YAML formats.
 
-### 2. OSCAL Validation
+### 2. OSCAL Extensions Support
 
-*   **Schema Validation:** The SDK **MUST** ensure the document adheres to the structural and data type constraints defined in the schema.
-*   **Semantic Validation:** The SDK **MUST** go beyond basic schema validation to check for logical consistency and best practices.
+*  **RuleSet Extension**: The SDK **MUST** define the OSCAL Compass `RuleSet` OSCAL extension in the target language.
+   *  The SDK **MUST** provide support for parsing and indexing rule information for OSCAL `Components`.
 
-### 3. OSCAL Transformation
+### 3. OSCAL Validation
 
-*   **Data Transformation:** The tool **MUST** manipulate and transform the data within an OSCAL document.
-  * Examples include:
-      *   The SDK **MUST** map data between different OSCAL models (e.g., SSP to AP).
+*   **Schema Validation:** The SDK **MUST** ensure the document adheres to the structural and data type constraints defined in the official OSCAL schemas.
+*   **Semantic Validation:** The SDK **SHOULD** go beyond basic schema validation to check for logical consistency and best practices.  
+    **Examples include:**
+      *   **Duplicate UUIDs**: Identify duplicate UUID in OSCAL models.
+      *   **Reference Validation**: All references in responsible parties are found in roles.
+      *   **Links Validation**: All UUIDs in links and prose match resources in backmatter
 
-### 4. OSCAL Profile Resolution
+### 4. OSCAL Transformation
 
-*   **Profile Resolution:** The SDK **MUST** support the OSCAL Profile Resolution Specification
+*   **Data Transformation:** The SDK **MUST** provide transformation workflows for the data within an OSCAL document.  
+    **Examples include:**
+      *   The SDK **MUST** map data between different OSCAL models including:
+          *   Profile to Catalog: See [OSCAL Profile Resolution](#5-oscal-profile-resolution)
+          *   Component Definition to SSP
+          *   Component Definition to Assessment Plan - **OPTIONAL**
+          *   SSP to Assessment Plan
+          *   Assessment Plan to Assessment Results
+      *   The SDK **MAY** map data between OSCAL and other data structures (e.g. XCCDF)
+
+### 5. OSCAL Profile Resolution
+
+*   **Profile Resolution:** The SDK **MUST** support the [OSCAL Profile Resolution Specification](https://pages.nist.gov/OSCAL/resources/concepts/processing/profile-resolution/)
+
+## Future Consideration
+
+* **Conformance Testing:**  Once the SDKs mature, specification conformance testing should be added to ensure each required use case is covered and the OSCAL inputs and outputs are consistent.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,34 @@
+# OSCAL Compass SDK Specification
+
+## Scope
+
+This document specifies the functional requirements for OSCAL Compass SDK developed to work with OSCAL documents.
+
+The keywords "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD,"
+"SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+## Non-Goals
+
+## Goals
+
+## Core Functionality
+
+### 1. Common OSCAL Extensions
+
+*  **Rule Extension**: The SDK **MUST** define and support workflow around the OSCAL Compass RuleSet OSCAL extension.
+
+### 2. OSCAL Validation
+
+*   **Schema Validation:** The SDK **MUST** ensure the document adheres to the structural and data type constraints defined in the schema.
+*   **Semantic Validation:** The SDK **MUST** go beyond basic schema validation to check for logical consistency and best practices.
+
+### 3. OSCAL Transformation
+
+*   **Data Transformation:** The tool **MUST** manipulate and transform the data within an OSCAL document.
+  * Examples include:
+      *   The SDK **MUST** map data between different OSCAL models (e.g., SSP to AP).
+
+### 4. OSCAL Profile Resolution
+
+*   **Profile Resolution:** The SDK **MUST** support the OSCAL Profile Resolution Specification


### PR DESCRIPTION
- Create an initial OSCAL Compass SDK specification to document common functionality all SDKs must implement

Closes #8 